### PR TITLE
Update zluda_installer.py to use Zluda's common naming structure

### DIFF
--- a/modules/zluda_installer.py
+++ b/modules/zluda_installer.py
@@ -82,15 +82,19 @@ def get_path() -> str:
 def install(zluda_path: os.PathLike) -> None:
     if os.path.exists(zluda_path):
         return
+#Fixed because Zluda changed naming structure so this always gave a 404 if you were on the wrong version of HIP
+    #also likelovewant made it so it was impossible to notify of the change needed forcing me to fork this into it's own repo just to make this update known...
+    #bruh...
 
     default_hash = None
-    #if HIPSDK.version == "6.2":
-    #    default_hash = 'new_hash_for_6_2'
+    if HIPSDK.version == "6.2":
+        default_hash = 'c4994b3093e02231339d22e12be08418b2af781f'
+        urllib.request.urlretrieve(f'https://github.com/lshqqytiger/ZLUDA/releases/download/rel.{os.environ.get("ZLUDA_HASH", default_hash)}/ZLUDA-windows-rocm6-amd64.zip', '_zluda')
     if HIPSDK.version == "6.1":
         default_hash = 'c0804ca624963aab420cb418412b1c7fbae3454b'
     elif HIPSDK.version == "5.7":
         default_hash = '11cc5844514f93161e0e74387f04e2c537705a82'
-    urllib.request.urlretrieve(f'https://github.com/lshqqytiger/ZLUDA/releases/download/rel.{os.environ.get("ZLUDA_HASH", default_hash)}/ZLUDA-windows-amd64.zip', '_zluda')
+        urllib.request.urlretrieve(f'https://github.com/lshqqytiger/ZLUDA/releases/download/rel.{os.environ.get("ZLUDA_HASH", default_hash)}/ZLUDA-windows-amd64.zip', '_zluda')
     with zipfile.ZipFile('_zluda', 'r') as archive:
         infos = archive.infolist()
         for info in infos:


### PR DESCRIPTION
Zluda url is currently broken and will throw a 404 error

Changing this in Zluda_installer.py fixes it:
(Also included the hash needed for 6_2 since that was missing)

Before:

`def install(zluda_path: os.PathLike) -> None:
    if os.path.exists(zluda_path):
        return

    default_hash = None
    #if HIPSDK.version == "6.2":
    #    default_hash = 'new_hash_for_6_2'
    if HIPSDK.version == "6.1":
        default_hash = 'c0804ca624963aab420cb418412b1c7fbae3454b'
    elif HIPSDK.version == "5.7":
        default_hash = '11cc5844514f93161e0e74387f04e2c537705a82'
    urllib.request.urlretrieve(f'https://github.com/lshqqytiger/ZLUDA/releases/download/rel.{os.environ.get("ZLUDA_HASH", default_hash)}/ZLUDA-windows-amd64.zip', '_zluda')
    with zipfile.ZipFile('_zluda', 'r') as archive:
        infos = archive.infolist()
        for info in infos:
            if not info.is_dir():
                info.filename = os.path.basename(info.filename)
                archive.extract(info, '.zluda')
    os.remove('_zluda')`

After:

`def install(zluda_path: os.PathLike) -> None:
    if os.path.exists(zluda_path):
        return

    default_hash = None
    if HIPSDK.version == "6.2":
        default_hash = 'c4994b3093e02231339d22e12be08418b2af781f'
        urllib.request.urlretrieve(f'https://github.com/lshqqytiger/ZLUDA/releases/download/rel.{os.environ.get("ZLUDA_HASH", default_hash)}/ZLUDA-windows-rocm6-amd64.zip', '_zluda')
    if HIPSDK.version == "6.1":
        default_hash = 'c0804ca624963aab420cb418412b1c7fbae3454b'
    elif HIPSDK.version == "5.7":
        default_hash = '11cc5844514f93161e0e74387f04e2c537705a82'
        urllib.request.urlretrieve(f'https://github.com/lshqqytiger/ZLUDA/releases/download/rel.{os.environ.get("ZLUDA_HASH", default_hash)}/ZLUDA-windows-amd64.zip', '_zluda')
    with zipfile.ZipFile('_zluda', 'r') as archive:
        infos = archive.infolist()
        for info in infos:
            if not info.is_dir():
                info.filename = os.path.basename(info.filename)
                archive.extract(info, '.zluda')
    os.remove('_zluda')`

